### PR TITLE
Fix: scss 변수 적용되지 않는 문제 해결

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,8 +1,3 @@
 @import url(//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css);
 @import './styles/common';
 @import './styles/reset';
-@import './styles/baseStyle/colors';
-@import './styles/baseStyle/z-index';
-@import './styles/baseStyle/font';
-@import './styles/baseStyle/size';
-@import './styles/baseStyle/border';


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- index.scss에서 한번에 scss 변수를 불러오도록 했는데 두가지 문제가 있었습니다.
1. 이렇게 import하면 불러와지지 않아 사용이 불가합니다.
2. 기능을 담당하신 분들마다 사용하시는 변수 주제(파일)가 다를 수 있는데 전부 불러오면 매우 불필요한 행위라는 것을 깨달았습니다.
이런 이유로 index.scss에서 scss 변수 파일들의 import를 제거하고 기능마다 해당하는 scss에서 import하기로 합니다.

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- index.scss에서 변수 파일들 import 제거
- 작업중인 scss 파일에서 직접 import해서 불러와 사용하는 것을 권장

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 변수의 유효범위는 변수가 선언된 블록( { } ) 내이기 때문에 선언할 변수의 스코프를 전역(Global Variable)로 할지, 아니면 부분(Local Variable)로 할지를 고려해 선언해야 한다는 것을 배웠습니다.

※ 전역변수로 전환하여 사용하고 싶을 때, 변수 선언 후 `!global`을 추가하면 된다고 배웠습니다.
그러나 변수명이 겹칠 수 있고 기능마다 필요하지 않은 변수 주제(파일)이 존재할 수 있으므로 `!global`은 선택사항에 없었습니다.

<br />

## :: 기타 질문 및 특이 사항

